### PR TITLE
Update EVENTUAL_BALL spec to match rephrased impl

### DIFF
--- a/ArtificialTheoremsSpec/RL/ApproxValueIterationIntSpec.lean
+++ b/ArtificialTheoremsSpec/RL/ApproxValueIterationIntSpec.lean
@@ -58,13 +58,10 @@ For any ε > (1/2)/(1-γ), the iterates eventually stay within distance ε of v*
 theorem INT_VALUE_ITERATION_EVENTUAL_BALL
     (mdp : MDP S A) (γ : ℚ) (hγ_nonneg : 0 ≤ γ) (hγ_lt : γ < 1)
     (ε : ℝ) (hε : ((1 : ℝ) / 2) / (1 - (γ : ℝ)) < ε) :
-    ∀ v₀ : S → ℤ, ∀ᶠ n in atTop,
-      let v_starWitness := Classical.choose
-        (INT_VALUE_ITERATION_APPROX (S:=S) (A:=A) mdp γ hγ_nonneg hγ_lt)
-      have hfix := (Classical.choose_spec
-        (INT_VALUE_ITERATION_APPROX (S:=S) (A:=A) mdp γ hγ_nonneg hγ_lt)).1
-      let v_star : S → ℝ := v_starWitness
-      dist (castZtoR ((bellmanOperatorInt (S:=S) (A:=A) mdp γ)^[n] v₀)) v_star ≤ ε := by
+    ∃ v_star : S → ℝ,
+      bellmanOperatorReal (S:=S) (A:=A) mdp (γ : ℝ) v_star = v_star ∧
+      ∀ v₀ : S → ℤ, ∀ᶠ n in atTop,
+        dist (castZtoR ((bellmanOperatorInt (S:=S) (A:=A) mdp γ)^[n] v₀)) v_star ≤ ε := by
   sorry
 
 end ApproxValueIterationInt


### PR DESCRIPTION
## Summary
- Update `ArtificialTheoremsSpec/RL/ApproxValueIterationIntSpec.lean` to match the rephrased `INT_VALUE_ITERATION_EVENTUAL_BALL` theorem from PR #7
- The spec now uses `∃ v_star` existential wrapper instead of `Classical.choose(INT_VALUE_ITERATION_APPROX ...)` in the type
- This ensures the comparator config works correctly (no cross-reference causing Phase 2 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)